### PR TITLE
Do not document explicitly deleted functions

### DIFF
--- a/src/indexer/Indexer.cpp
+++ b/src/indexer/Indexer.cpp
@@ -126,7 +126,9 @@ void hdoc::indexer::Indexer::updateRecordNames() {
 void hdoc::indexer::Indexer::updateMemberFunctions() {
   for (auto& [k, c] : this->index.records.entries) {
     for (auto& symbol : c.methodIDs) {
-      auto& f = this->index.functions.entries[symbol];
+      if (!this->index.functions.contains(symbol)) continue;
+
+      auto& f = this->index.functions.entries.at(symbol);
       // split the proto into parts
       std::string templatePart = f.proto.substr(0, f.postTemplate);
       std::string preNamePart = f.proto.substr(f.postTemplate, f.nameStart - f.postTemplate);

--- a/src/indexer/Matchers.cpp
+++ b/src/indexer/Matchers.cpp
@@ -66,6 +66,11 @@ static hdoc::types::SymbolID getTypeSymbolID(const clang::QualType& typ) {
 void hdoc::indexer::matchers::FunctionMatcher::run(const clang::ast_matchers::MatchFinder::MatchResult& Result) {
   const auto res = Result.Nodes.getNodeAs<clang::FunctionDecl>("function");
 
+  // We must either deliberately ignore deleted functions or document them as deleted. Doing neither will mean
+  // they show up as _defined_, which is the opposite of the truth. Not listing them is the easier way out; if
+  // we ever do want document them we should also document implicitly deleted constructors and functions.
+  if (res->isDeletedAsWritten()) return;
+
   // Ignore deduction guides, at least for now
   // (generally, these usually are designed to make things work as one would expect, so
   //  having documentation for them is not as important as for other things)


### PR DESCRIPTION
Previously, explicitly-deleted member functions showed up as defined, which is obviously wrong. Since a) functions can also be deleted implicitly and b) I'm unsure what the _documentation_ for a deleted function should look like, I've opted for not exporting them altogether.

This requires an additional check in `Indexer::updateRecordNames()` to avoid default-constructing non-existing DB entries.