### PR TITLE
Attach hidden friend functions to their struct / class

### DIFF
--- a/src/indexer/MatcherUtils.cpp
+++ b/src/indexer/MatcherUtils.cpp
@@ -215,6 +215,7 @@ std::string getFunctionSignature(hdoc::types::FunctionSymbol& f) {
   f.postTemplate = signature.size();
 
   // Various qualifiers
+  signature += f.isHiddenFriend ? "friend " : "";
   signature += f.storageClass == clang::SC_Static ? "static " : "";
   signature += f.storageClass == clang::SC_Extern ? "extern " : "";
   signature += f.isInline ? "inline " : "";

--- a/src/indexer/Matchers.cpp
+++ b/src/indexer/Matchers.cpp
@@ -63,6 +63,12 @@ static hdoc::types::SymbolID getTypeSymbolID(const clang::QualType& typ) {
   }
 }
 
+static bool isHiddenFriendFunction(const clang::Decl* res) {
+  return res != nullptr && (llvm::isa<clang::FunctionDecl>(res) || llvm::isa<clang::FunctionTemplateDecl>(res)) &&
+         res->isCanonicalDecl() && res->getLexicalDeclContext()->getDeclKind() == clang::Decl::Kind::CXXRecord &&
+         res->getDeclContext()->getDeclKind() == clang::Decl::Kind::Namespace;
+}
+
 void hdoc::indexer::matchers::FunctionMatcher::run(const clang::ast_matchers::MatchFinder::MatchResult& Result) {
   const auto res = Result.Nodes.getNodeAs<clang::FunctionDecl>("function");
 
@@ -170,8 +176,10 @@ void hdoc::indexer::matchers::FunctionMatcher::run(const clang::ast_matchers::Ma
     // simplify name of the constructors to remove template arguments in case it is a specialization
     f.name = std::regex_replace(f.name, std::regex("<.*>"), "");
   }
-  f.proto          = getFunctionSignature(f);
   f.isRecordMember = res->isCXXClassMember();
+  f.isHiddenFriend = isHiddenFriendFunction(res);
+
+  f.proto          = getFunctionSignature(f);
 
   fillNamespace(f, res, this->cfg);
   this->index->functions.update(f.ID, f);
@@ -366,6 +374,12 @@ void hdoc::indexer::matchers::RecordMatcher::run(const clang::ast_matchers::Matc
         continue;
       }
       c.methodIDs.emplace_back(buildID(ftd));
+    } else if (const auto* fd = llvm::dyn_cast<clang::FriendDecl>(d)) {
+      if (const auto namedFriend = fd->getFriendDecl(); isHiddenFriendFunction(namedFriend)) {
+        c.hiddenFriendIDs.emplace_back(buildID(namedFriend));
+        spdlog::debug(
+            "Added hidden friend {} of {}", namedFriend->getQualifiedNameAsString(), res->getQualifiedNameAsString());
+      }
     } else {
       // add aliases
       const clang::NamedDecl* alias = llvm::dyn_cast<clang::UsingShadowDecl>(d);

--- a/src/serde/HTMLWriter.cpp
+++ b/src/serde/HTMLWriter.cpp
@@ -538,7 +538,7 @@ void hdoc::serde::HTMLWriter::printFunctions() const {
   CTML::Node ul("ul");
   for (const auto& id : getSortedIDs(map2vec(this->index->functions), this->index->functions)) {
     const auto& f = this->index->functions.entries.at(id);
-    if (f.isRecordMember) {
+    if (f.isRecordMember || f.isHiddenFriend) {
       continue;
     }
     numFunctions += 1;
@@ -763,6 +763,38 @@ printInheritedMethods(const hdoc::types::Index* index, const hdoc::types::Record
   }
 }
 
+static CTML::Node printFunctionOverview(const std::vector<hdoc::types::SymbolID>& ids,
+                                        const hdoc::types::Index&                 index) {
+  CTML::Node ul("ul");
+  for (auto fnID : ids) {
+    const hdoc::types::FunctionSymbol m = index.functions.entries.at(fnID);
+
+    // Divide up the full function declaration so its name can be bold in the HTML
+    // and to reformat it for the overview list with trailing return type
+    const uint64_t    nameLen      = m.name.size();
+    const std::string templatePart = m.proto.substr(0, m.postTemplate);
+    std::string       retTypePart  = m.proto.substr(m.postTemplate, m.nameStart - m.postTemplate);
+    const std::string inlineMarker = "inline";
+    if (retTypePart.starts_with(inlineMarker)) {
+      retTypePart = retTypePart.substr(inlineMarker.size());
+    }
+    hdoc::utils::trim(retTypePart);
+    const std::string postName = m.proto.substr(m.nameStart + nameLen, m.proto.size() - m.nameStart - nameLen);
+
+    auto li = CTML::Node("li.is-family-code");
+    if (!templatePart.empty())
+      li.AddChild(CTML::Node("span.hdoc-overview-template", templatePart)).AppendRawHTML("<br>");
+    li.AddChild(CTML::Node("a").SetAttr("href", "#" + m.ID.str()).AddChild(CTML::Node("b", m.name)));
+    li.AppendText(postName);
+    if (!retTypePart.empty())
+      li.AppendRawHTML(" &rarr; ").AppendText(retTypePart);
+    if (m.access == clang::AS_private)
+      li.ToggleClass("hdoc-private");
+    ul.AddChild(li);
+  }
+  return ul;
+}
+
 /// Print a record to main
 void hdoc::serde::HTMLWriter::printRecord(const hdoc::types::RecordSymbol& c) const {
   CTML::Node main("main");
@@ -862,31 +894,7 @@ void hdoc::serde::HTMLWriter::printRecord(const hdoc::types::RecordSymbol& c) co
   if (sortedMethodIDs.size() > 0) {
     main.AddChild(CTML::Node("h2", "Member Function Overview"));
     hasMethodOverviewHeading = true;
-    CTML::Node ul("ul");
-    for (auto methodID : sortedMethodIDs) {
-      const hdoc::types::FunctionSymbol m = this->index->functions.entries.at(methodID);
-
-      // Divide up the full function declaration so its name can be bold in the HTML
-      // and to reformat it for the overview list with trailing return type
-      const uint64_t    nameLen  = m.name.size();
-      const std::string templatePart = m.proto.substr(0, m.postTemplate);
-      std::string retTypePart  = m.proto.substr(m.postTemplate, m.nameStart - m.postTemplate);
-      const std::string inlineMarker = "inline";
-      if(retTypePart.starts_with(inlineMarker)) {
-        retTypePart = retTypePart.substr(inlineMarker.size());
-      }
-      hdoc::utils::trim(retTypePart);
-      const std::string postName = m.proto.substr(m.nameStart + nameLen, m.proto.size() - m.nameStart - nameLen);
-
-      auto li = CTML::Node("li.is-family-code");
-      if(!templatePart.empty()) li.AddChild(CTML::Node("span.hdoc-overview-template", templatePart)).AppendRawHTML("<br>");
-      li.AddChild(CTML::Node("a").SetAttr("href", "#" + m.ID.str()).AddChild(CTML::Node("b", m.name)));
-      li.AppendText(postName);
-      if(!retTypePart.empty()) li.AppendRawHTML(" &rarr; ").AppendText(retTypePart);
-      if(m.access == clang::AS_private) li.ToggleClass("hdoc-private");
-      ul.AddChild(li);
-    }
-    main.AddChild(ul);
+    main.AddChild(printFunctionOverview(sortedMethodIDs, *this->index));
   }
 
   // Add inherited methods to the list
@@ -897,6 +905,13 @@ void hdoc::serde::HTMLWriter::printRecord(const hdoc::types::RecordSymbol& c) co
       hasMethodOverviewHeading = true;
     }
     printInheritedMethods(this->index, ic, main);
+  }
+
+  // Hidden-friend function overview in list form
+  const auto& sortedHiddenFriendIDs = getSortedIDs(c.hiddenFriendIDs, this->index->functions);
+  if (sortedHiddenFriendIDs.size() > 0) {
+    main.AddChild(CTML::Node("h2", "Friend Function Overview"));
+    main.AddChild(printFunctionOverview(sortedHiddenFriendIDs, *this->index));
   }
 
   // List of methods with full information
@@ -910,6 +925,15 @@ void hdoc::serde::HTMLWriter::printRecord(const hdoc::types::RecordSymbol& c) co
       }
       printFunction(
           this->index->functions.entries.at(methodID), main, this->cfg->gitRepoURL, this->cfg->gitDefaultBranch);
+    }
+  }
+
+  // List hidden friend functions with full information
+  if (sortedHiddenFriendIDs.size() > 0) {
+    main.AddChild(CTML::Node("h2", "Friend Functions"));
+    for (const auto& friendID : sortedHiddenFriendIDs) {
+      printFunction(
+          this->index->functions.entries.at(friendID), main, this->cfg->gitRepoURL, this->cfg->gitDefaultBranch);
     }
   }
 
@@ -1119,10 +1143,11 @@ We have left the Javascript code unminified so that you are able to inspect it y
     for (const auto& s : this->index->functions.entries)
       json.object([&] {
         auto& f = s.second;
-        json.attribute("sid", f.isRecordMember ? f.parentNamespaceID.str() + ".html#" + f.ID.str() : f.ID.str());
+        const auto listAsMember = f.isRecordMember || f.isHiddenFriend;
+        json.attribute("sid", listAsMember ? f.parentNamespaceID.str() + ".html#" + f.ID.str() : f.ID.str());
         json.attribute("name", f.name);
         json.attribute("decl", f.proto);
-        json.attribute("type", f.isRecordMember ? 0 : 1);
+        json.attribute("type", listAsMember ? 0 : 1);
       });
 
     for (const auto& s : this->index->records.entries) {

--- a/src/types/Symbols.hpp
+++ b/src/types/Symbols.hpp
@@ -57,14 +57,14 @@ struct SymbolID {
 
 /// @brief Base class for all other types of symbols
 struct Symbol {
-  std::string           name = "";              ///< Function name, record name, enum name etc.
-  std::string           briefComment = "";      ///< Text following @brief or \brief command
-  std::string           docComment = "";        ///< All other Doxygen text attached to this symbol's documentation
-  hdoc::types::SymbolID ID;                     ///< Unique identifier for this Symbol
-  std::string           file = "";              ///< File where this Symbol is declared, relative to source root
-  std::uint64_t         line = 0;               ///< Line number in the file
-  hdoc::types::SymbolID parentNamespaceID;      ///< ID of the parent namespace (or record)
-  bool                  isDetail = false;       ///< Is this symbol in a "detail" namespace?
+  std::string           name         = ""; ///< Function name, record name, enum name etc.
+  std::string           briefComment = ""; ///< Text following @brief or \brief command
+  std::string           docComment   = ""; ///< All other Doxygen text attached to this symbol's documentation
+  hdoc::types::SymbolID ID;                ///< Unique identifier for this Symbol
+  std::string           file = "";         ///< File where this Symbol is declared, relative to source root
+  std::uint64_t         line = 0;          ///< Line number in the file
+  hdoc::types::SymbolID parentNamespaceID; ///< ID of the parent namespace (or record)
+  bool                  isDetail = false;  ///< Is this symbol in a "detail" namespace?
 
   /// @brief Comparison operator sorts alphabetically by symbol name, sort detail symbols last
   bool operator<(const Symbol& s) const {
@@ -104,9 +104,9 @@ struct TemplateParam {
 /// @brief Represents a using declaration or similar alias
 struct AliasSymbol : public Symbol {
 public:
-  TypeRef target;                                    ///< The type this using declaration aliases
-  bool isRecordMember = false;                       ///< Is it a member alias?
-  clang::AccessSpecifier access = clang::AS_private; ///< Access type, i.e. public/protected/private
+  TypeRef                target;                             ///< The type this using declaration aliases
+  bool                   isRecordMember = false;             ///< Is it a member alias?
+  clang::AccessSpecifier access         = clang::AS_private; ///< Access type, i.e. public/protected/private
 
   std::string url() const {
     return "a" + this->ID.str() + ".html";
@@ -132,13 +132,14 @@ struct RecordSymbol : public Symbol {
     std::string            name;   ///< Name of the record, used only for base records in std:: which aren't indexed
   };
 
-  std::string                        type;           ///< i.e. struct/class/union
-  std::string                        proto;          ///< Full class prototype, including
-  std::vector<MemberVariable>        vars;           ///< All of this record's member variables
-  std::vector<hdoc::types::SymbolID> methodIDs;      ///< All of this record's methods
-  std::vector<BaseRecord>            baseRecords;    ///< All of the records this record inherits from
-  std::vector<TemplateParam>         templateParams; ///< All of the template parameters for this record
-  std::vector<hdoc::types::SymbolID> aliasIDs;       ///< All of the aliases in this record
+  std::string                        type;            ///< i.e. struct/class/union
+  std::string                        proto;           ///< Full class prototype, including
+  std::vector<MemberVariable>        vars;            ///< All of this record's member variables
+  std::vector<hdoc::types::SymbolID> methodIDs;       ///< All of this record's methods
+  std::vector<BaseRecord>            baseRecords;     ///< All of the records this record inherits from
+  std::vector<TemplateParam>         templateParams;  ///< All of the template parameters for this record
+  std::vector<hdoc::types::SymbolID> aliasIDs;        ///< All of the aliases in this record
+  std::vector<hdoc::types::SymbolID> hiddenFriendIDs; ///< All functions  declared as hidden friends of this record
 
   std::string url() const {
     return "r" + this->ID.str() + ".html";
@@ -157,6 +158,7 @@ struct FunctionParam {
 struct FunctionSymbol : public Symbol {
 public:
   bool                       isRecordMember    = false; ///< Is it a method?
+  bool                       isHiddenFriend    = false; ///< is hidden friend (friend with function body)?
   bool                       isConstexpr       = false; ///< Is it marked constexpr?
   bool                       isConsteval       = false; ///< Is it marked consteval?
   bool                       isInline          = false; ///< Is it marked inline?


### PR DESCRIPTION
Previously, hidden friend functions ended up in the (semantically correct) enclosing namespace. This PR lists them in the record documentation as a separate "Friend Functions" section instead to group operators, swap functions et cetera with the class or struct they were defined for.